### PR TITLE
[cmake]Use correct file name CpGridDataTraits.hpp for install

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -164,7 +164,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/grid/common/WellConnections.hpp
   opm/grid/cpgrid/CartesianIndexMapper.hpp
   opm/grid/cpgrid/CpGridData.hpp
-  opm/grid/cpgrid/CpGridDataTraits
+  opm/grid/cpgrid/CpGridDataTraits.hpp
   opm/grid/cpgrid/DataHandleWrappers.hpp
   opm/grid/cpgrid/DefaultGeometryPolicy.hpp
   opm/grid/cpgrid/dgfparser.hh


### PR DESCRIPTION
Sorry , I mispelled the file name in the CMake files. Merging this should fix the build of your PR.