### PR TITLE
Support ALUGrid for LookupData

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -114,6 +114,7 @@ if(Boost_VERSION_STRING VERSION_GREATER 1.53)
 	  tests/cpgrid/geometry_test.cpp
 	  tests/cpgrid/grid_lgr_test.cpp
 	  tests/cpgrid/lookupdata_test.cpp
+	  tests/cpgrid/lookupdata_general_test.cpp
 	  tests/cpgrid/lookupdataCpGrid_test.cpp
 	  tests/cpgrid/shifted_cart_test.cpp
   )

--- a/opm/grid/LookUpData.hh
+++ b/opm/grid/LookUpData.hh
@@ -43,10 +43,11 @@ class LookUpData
 {
 public:
     // Constructor taking a Grid object
-    LookUpData(const Grid& grid) :
-        gridView_(grid.leafGridView()),
+    LookUpData(const GridView& gridView,
+               const CartesianIndexMapper<Grid>& mapper) :
+        gridView_(gridView),
         elemMapper_(gridView_, Dune::mcmgElementLayout()),
-        cartMapper_(grid)
+        cartMapper_(&mapper)
     {
     }
 
@@ -54,7 +55,7 @@ public:
     LookUpData(const  GridView& gridView) :
         gridView_(gridView),
         elemMapper_(gridView_, Dune::mcmgElementLayout()),
-        cartMapper_(gridView_.grid())
+        cartMapper_()
     {
     }
 
@@ -70,7 +71,8 @@ public:
     template<typename FeatureType>
     FeatureType operator()(const int& elemIdx, const std::vector<FeatureType> feature_vec) const
     {
-        const int& cartIdx = cartMapper_.cartesianIndex(elemIdx);
+        assert(cartMapper_);
+        const int& cartIdx = cartMapper_->cartesianIndex(elemIdx);
         assert(0 <= cartIdx && static_cast<int>(feature_vec.size()) > cartIdx);
         return feature_vec[cartIdx];
     }
@@ -83,9 +85,9 @@ public:
     }
 
 protected:
-    GridView gridView_;
+    const GridView& gridView_;
     Dune::MultipleCodimMultipleGeomTypeMapper<GridView> elemMapper_;
-    Dune::CartesianIndexMapper<Grid> cartMapper_;
+    const Dune::CartesianIndexMapper<Grid>* cartMapper_;
 
 
 }; // end LookUpData class

--- a/opm/grid/LookUpDataCpGrid.hh
+++ b/opm/grid/LookUpDataCpGrid.hh
@@ -35,9 +35,9 @@
 namespace Dune
 {
 template <typename Grid, typename GridView>
-class LookUpData
-{
-};
+class LookUpData;
+
+
 /// Specialization for CpGrid
 template<typename GridView>
 class LookUpData<CpGrid, GridView>

--- a/opm/grid/LookUpDataCpGrid.hh
+++ b/opm/grid/LookUpDataCpGrid.hh
@@ -40,12 +40,17 @@ class LookUpData
 };
 /// Specialization for CpGrid
 template<typename GridView>
-class LookUpData<Dune::CpGrid, GridView>
+class LookUpData<CpGrid, GridView>
 {
 public:
     // Constructor taking a CpGrid object
-    LookUpData(const Dune::CpGrid&){
+    LookUpData(const GridView&,
+               const CartesianIndexMapper<CpGrid>&){
     }
+
+    // Constructor taking a CpGrid object
+    LookUpData(const GridView&)
+    {}
 
     template<typename feature_type>
     int operator()(const Dune::cpgrid::Entity<0>& elem, const std::vector<feature_type>& feature_vec)

--- a/tests/cpgrid/lookupdataCpGrid_test.cpp
+++ b/tests/cpgrid/lookupdataCpGrid_test.cpp
@@ -74,7 +74,7 @@ void lookup_check(const Dune::CpGrid& grid)
     std::iota(fake_feature.begin(), fake_feature.end(), 3);
     const auto& leaf_view = grid.leafGridView();
 
-    Dune::LookUpData<Dune::CpGrid, Dune::GridView<Dune::DefaultLevelGridViewTraits<Dune::CpGrid>>> lookUpData(grid);
+    Dune::LookUpData<Dune::CpGrid, Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>> lookUpData(leaf_view);
 
     const auto& level0_view = grid.levelGridView(0);
     Dune::MultipleCodimMultipleGeomTypeMapper<Dune::CpGrid::LeafGridView> leafMapper(leaf_view, Dune::mcmgElementLayout());

--- a/tests/cpgrid/lookupdata_general_test.cpp
+++ b/tests/cpgrid/lookupdata_general_test.cpp
@@ -71,7 +71,8 @@ void lookup_check(const Dune::CpGrid& grid)
     std::iota(fake_feature.begin(), fake_feature.end(), 3);
 
     const auto& leaf_view = grid.leafGridView();
-    Dune::LookUpData<Dune::CpGrid> lookUpData(grid);
+    using GridView = std::remove_cv_t< typename std::remove_reference<decltype(grid.leafGridView())>::type>;
+    Dune::LookUpData<Dune::CpGrid, GridView> lookUpData(leaf_view);
 
     for (const auto& elem : elements(leaf_view)) {
         auto featureInElem = lookUpData(elem, fake_feature);

--- a/tests/cpgrid/lookupdata_test.cpp
+++ b/tests/cpgrid/lookupdata_test.cpp
@@ -71,7 +71,7 @@ void lookup_check(const Dune::CpGrid& grid)
     std::iota(fake_feature.begin(), fake_feature.end(), 3);
 
     const auto& leaf_view = grid.leafGridView();
-    Dune::LookUpData<Dune::CpGrid, Dune::GridView<Dune::DefaultLevelGridViewTraits<Dune::CpGrid>>> lookUpData(grid);
+    Dune::LookUpData<Dune::CpGrid, Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>> lookUpData(leaf_view);
 
     for (const auto& elem : elements(leaf_view)) {
         auto featureInElem = lookUpData(elem, fake_feature);


### PR DESCRIPTION
For ALUGrid the cartesian index mapper needs to be instantiated in a very special way and one cannot create it just by passing a reference to the grid.  This creation is done in opm-simulators/ebos/eclalugridvanguard.hh. Then the mapper can be accessed from the Vanguard and passed to LookupData. For this one constructor now takes the mapper as an extra argument.
    
To still allow a construction from just the grid view, the class stores a pointer to the mapper which is a nullptr if no mapper was provided from the outside.
    
In addition change the constructors from taking a grid to taking a grid view instead. From the grid view it is possible to access the  underlying grid, too.

I have also activated the compilation of lookupdata_general_test.cpp
