### PR TITLE
Add a member current_data_ to Cpgrid that points to correct container

### DIFF
--- a/opm/grid/CpGrid.hpp
+++ b/opm/grid/CpGrid.hpp
@@ -1865,6 +1865,8 @@ namespace Dune
         cpgrid::CpGridData* current_view_data_;
         /** @brief The data stored for the distributed grid. */
         std::vector<std::shared_ptr<cpgrid::CpGridData>> distributed_data_;
+        /** @brief A pointer to the current data used. */
+        std::vector<std::shared_ptr<cpgrid::CpGridData>>* current_data_;
         /** @brief To get the level given the lgr-name. Default, {"GLOBAL", 0}. */
         std::map<std::string,int> lgr_names_ = {{"GLOBAL", 0}};
         /**


### PR DESCRIPTION
After distributing this is distributed_data_, before data_. It also changes after calling switchToGlobalView or switchToDistributedView.

Having this member makes the LGR code easier,